### PR TITLE
Admin and guest users, legal notice splitting.

### DIFF
--- a/Windows Server 2022 Baseline.ps1
+++ b/Windows Server 2022 Baseline.ps1
@@ -1133,10 +1133,19 @@ function LimitBlankPasswordConsole {
 
 function RenameAdministratorAccount {
     #2.3.1.5 => Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Accounts: Rename administrator account
-    Write-Info "2.3.1.5 (L1) Configure 'Accounts: Rename administrator account'"
-    SetSecurityPolicy "NewAdministratorName" (,"`"$($AdminNewAccountName)`"")
-    Set-LocalUser -Name $AdminNewAccountName -Description " "
+    $RenamedUser = $AdminNewAccountName -replace "\d",""
+    $RenamedUser = Get-LocalUser -Name $RenamedUser*
+    if ($RenamedUser) {
+        Write-Red "Skipping 2.3.1.5 (L1) Configure 'Accounts: Rename administrator account'"
+        Write-Red "- Administrator account already renamed: $($RenamedUser.Name)."
+    }
+    else {
+        Write-Info "2.3.1.5 (L1) Configure 'Accounts: Rename administrator account'"
+        SetSecurityPolicy "NewAdministratorName" (,"`"$($AdminNewAccountName)`"")
+        Set-LocalUser -Name $AdminNewAccountName -Description ""
+    }
 }
+
 
 function RenameGuestAccount {
     #2.3.1.6 => Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Accounts: Rename guest account

--- a/Windows Server 2022 Baseline.ps1
+++ b/Windows Server 2022 Baseline.ps1
@@ -721,9 +721,18 @@ function SetSecurityPolicy([string]$role, [string[]] $values, $enforceCreation=$
 }
 
 function CreateUserAccount([string] $username, [securestring] $password, [bool] $isAdmin=$false) {
-    New-LocalUser -Name $username -Password $password -Description "" -AccountNeverExpires -PasswordNeverExpires
-    if($isAdmin -eq $true) {
-        Add-LocalGroupMember -Group "Administrators" -Member $username
+    $NewLocalAdminExists = Get-LocalUser -Name $username -ErrorAction SilentlyContinue
+    if ($NewLocalAdminExists) {
+        Write-Red "Skipping creating new Administrator account"
+        Write-Red "- New Administrator account already exists: $($username)"
+    }
+    else {
+        New-LocalUser -Name $username -Password $password -Description "" -AccountNeverExpires -PasswordNeverExpires
+        Write-Info "New Administrator account created: $($username)."
+        if($isAdmin -eq $true) {
+            Add-LocalGroupMember -Group "Administrators" -Member $username
+            Write-Info "Administrator account $($username) is now member of the local Administrators group."
+        }
     }
 }
 

--- a/Windows Server 2022 Baseline.ps1
+++ b/Windows Server 2022 Baseline.ps1
@@ -1149,9 +1149,17 @@ function RenameAdministratorAccount {
 
 function RenameGuestAccount {
     #2.3.1.6 => Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Accounts: Rename guest account
-    Write-Info "2.3.1.6 (L1) Configure 'Accounts: Rename guest account'"
-    SetSecurityPolicy "NewGuestName" (,"`"$($GuestNewAccountName)`"")
-    Set-LocalUser -Name $GuestNewAccountName -Description " "
+    $RenamedUser = $GuestNewAccountName -replace "\d",""
+    $RenamedUser = Get-LocalUser -Name $RenamedUser*
+    if ($RenamedUser) {
+        Write-Red "Skipping 2.3.1.6 (L1) Configure 'Accounts: Rename guest account'"
+        Write-Red "- Guest account already renamed: $($RenamedUser.Name)."
+    }
+    else {
+        Write-Info "2.3.1.6 (L1) Configure 'Accounts: Rename guest account'"
+        SetSecurityPolicy "NewGuestName" (,"`"$($GuestNewAccountName)`"")
+        Set-LocalUser -Name $GuestNewAccountName -Description ""
+    }
 }
 
 function AuditForceSubCategoryPolicy {

--- a/Windows Server 2022 Baseline.ps1
+++ b/Windows Server 2022 Baseline.ps1
@@ -644,7 +644,9 @@ function ResetSec {
 
 function SetSecEdit([string]$role, [string[]] $values, $area, $enforceCreation) {
     $valueSet = $false
-    $values = $values.Split('',[System.StringSplitOptions]::RemoveEmptyEntries)
+    if ($role -notlike "*LegalNotice*") {
+        $values = $values.Split('',[System.StringSplitOptions]::RemoveEmptyEntries)
+    }
 
     if($null -eq $values) {
         Write-Error "SetSecEdit: At least one value must be provided to set the role:$($role)"


### PR DESCRIPTION
Error handling and check for the new admin user, default admin and default guest account. The script won't throw an error when the new local admin is already created.

For the default admin and default guest account, it checks if the renaming policy is already configured. Then prints the current name to the console and skips the renaming.

Splitting the values in SetSecEdit function, also adds a comma in the legal notice message. This will put every word on a single line.