### PR TITLE
Changes to Guest/Admin check and setting passwords

### DIFF
--- a/Windows Server 2022 Baseline.ps1
+++ b/Windows Server 2022 Baseline.ps1
@@ -3233,13 +3233,13 @@ if(([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::G
     $invalid_pass = $true
 
     if($NewLocalAdminUsername) {
-        if(!($NewLocalAdminPswd)) {
+        if(!($NewLocalAdminPassword)) {
             Write-Red "NewLocalAdminUsername set but NewLocalAdminPasswd not set."
             Write-Red "Please use -NewLocalAdminPassword parameter to set the password."
             Write-Red "Aborted."
             return
         } else {
-            if((ValidatePasswords $NewLocalAdminPswd $NewLocalAdminPswd) -eq $False) {
+            if((ValidatePasswords $NewLocalAdminPassword $NewLocalAdminPassword) -eq $False) {
                 Write-Red "NewLocalAdminPassword does not fullfill the minimum security requirements."
                 Write-Info "Your passwords must contain at least 15 characters, capital letters, numbers and symbols."
                 return 1;


### PR DESCRIPTION
Moved the Admin/Guest user check to the beginning of the script, where the new users are randomized. When rerunning the script on a system that's already hardened, the SetUserRight function fails because it uses new randomized accounts as input.

Modified the ValidatePasswords function and if statements to save passwords as a secure string.